### PR TITLE
add ANONYMOUS_ROLE environment variable, Anonymous (not logged in) users

### DIFF
--- a/docs/hasura-config.md
+++ b/docs/hasura-config.md
@@ -28,6 +28,7 @@ services:
       KEYCLOAK_SERVER_URL: ${KEYCLOAK_URL} # Keycloak url in term of http://keycloak.COMPANY.com/auth
       KEYCLOAK_REALM: ${KEYCLOAK_REALM} # Default to master if any new create change to it
       KEYCLOAK_SECRET: ${KEYCLOAK_SECRET} # Secret copied from the backend client -> Credentials
+      ANONYMOUS_ROLE: "anonymous" # (optional) Use this variable to set anonymous role name for unauthorized users as shown in the documentation: https://docs.hasura.io/1.0/graphql/manual/auth/authorization/common-roles-auth-examples.html#anonymous-not-logged-in-users
       KEYCLOAK_DEBUG: "true" # If testing enable mention this file
 
 volumes:

--- a/src/config.js
+++ b/src/config.js
@@ -21,6 +21,12 @@ const config = convict({
         default: false,
         env: 'KEYCLOAK_DEBUG',
     },
+    AnonymousRole: {
+        doc: 'AnonymousRole used if the user not loged in',
+        format: String,
+        default: null,
+        env: 'ANONYMOUS_ROLE',
+    },
     kcConfig: {
         clientId: {
             doc: 'Keycloak config',

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ const { tokenParser } = require('./token');
 const packageJson = require('../package');
 
 const debugMode = config.get('debugMode');
+const AnonymousRole = config.get('AnonymousRole');
 
 if (debugMode) {
     app.get('*', (res, req, next) => {
@@ -16,7 +17,14 @@ if (debugMode) {
 
 app.get('/', keycloak.middleware(), (res, req) => {
     if (!res.kauth.grant) {
-        return req.sendStatus(401);
+        if(AnonymousRole){
+            return req.status(200)
+            .jsonp({
+                 'X-Hasura-Role':AnonymousRole
+            });
+        }else{
+            return req.sendStatus(401);
+        }
     }
 
     const tokenParsed = tokenParser(res.kauth.grant, config.get('kcConfig.clientId'), debugMode);


### PR DESCRIPTION
this `ANONYMOUS_ROLE` variable is optional and  allows to use a default role if the user is not authorized and Anonymous (not logged in) users as mentioned in the documentation here: 
https://docs.hasura.io/1.0/graphql/manual/auth/authorization/common-roles-auth-examples.html#anonymous-not-logged-in-users